### PR TITLE
Adds a reference to the paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This folder contains code and data to reproduce analyses from the paper *Targeted sequencing in DLBCL, molecular subtypes, and outcomes: a Haematological Malignancy Research Network report*, published in XX XX.
+This folder contains code and data to reproduce analyses from [Lacy, Stuart E., et al. "Targeted sequencing in DLBCL, molecular subtypes, and outcomes: a Haematological Malignancy Research Network report." Blood 135.20 (2020): 1759-1771](https://doi.org/10.1182/blood.2019003535)
 
 The contents are as follows:
 

--- a/fit_clusters.R
+++ b/fit_clusters.R
@@ -53,15 +53,20 @@ plot(ex)
 # Extract these models
 aic <- getModel(ex, which = "AIC")
 bic <- getModel(ex, which = "BIC")
+icl <- getModel(ex, which = "ICL")
 
 # Save cluster assignments in main data frame
 muts_all$ClusterAIC <- as.factor(paste0('C', aic@cluster))
-muts_all$ClusterICL <- as.factor(paste0('C', bic@cluster))
+muts_all$ClusterBIC <- as.factor(paste0('C', bic@cluster))
+muts_all$ClusterICL <- as.factor(paste0('C', icl@cluster))
 
 # Plot heatmaps of enriched mutations
 genes <- colnames(muts_df)
 plt_aic <- heatmap_mutation_extended(muts_all, genes, 'ClusterAIC', y_order = 'group', idcol = 'PID')
 grid.arrange(plt_aic)
+
+plt_bic <- heatmap_mutation_extended(muts_all, genes, 'ClusterBIC', y_order = 'group', idcol = 'PID')
+grid.arrange(plt_bic)
 
 plt_icl <- heatmap_mutation_extended(muts_all, genes, 'ClusterICL', y_order = 'group', idcol = 'PID')
 grid.arrange(plt_icl)

--- a/fit_clusters.R
+++ b/fit_clusters.R
@@ -96,10 +96,14 @@ predict_clusters <- function(model, newdata) {
 # prediction process will overwrite this variable
 orig_df <- muts_df
 test_data <- orig_df[1:10, ]
-predict_clusters(aic, test_data)
+probs_aic <- predict_clusters(aic, test_data)
+colnames(probs_aic) <- c("BCL2", "TET2/SGK1", "SOCS1/SGK1", "NOTCH2", "MYD88", "NEC")
+probs_aic
 
 # BIC model returns 4 columns
-predict_clusters(bic, test_data)
+probs_bic <- predict_clusters(bic, test_data)
+colnames(probs_bic) <- c("SGK1", "BCL2", "NEC", "MYD88")
+probs_bic
 
 # View predicted cluster membership for an imaginary sample.
 # This will use as an example a sample with a number of mutations associated with MYD88
@@ -113,4 +117,6 @@ new_df$CD79B <- 1
 
 # From the heatmap it can be observed that MYD88 is the 5th cluster, which is consistent
 # with the predicted 93% assignment for this imaginary sample.
-predict_clusters(aic, new_df)
+probs_aic <- predict_clusters(aic, new_df)
+colnames(probs_aic) <- c("BCL2", "TET2/SGK1", "SOCS1/SGK1", "NOTCH2", "MYD88", "NEC")
+probs_aic


### PR DESCRIPTION
Adds a reference to the Blood publication this software refers to in the README. 
Also makes an explicit distinction between the ICL and BIC cluster selection criterion.

Closes #1 